### PR TITLE
Fix type RFC reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The URI of the linked sub-entity.  Required.
 
 ##### `type`
 
-Defines media type of the linked sub-entity, per [Web Linking (RFC5988)](http://tools.ietf.org/html/rfc5988).  Optional.
+Defines media type of the linked sub-entity, per [Media Type Specifications and Registration Procedures (RFC4288)](https://tools.ietf.org/html/rfc4288).  Optional.
 
 ##### `title`
 Descriptive text about the entity.  Optional.
@@ -168,7 +168,7 @@ Text describing the nature of a link.  Optional.
 
 ### `type`
 
-Defines media type of the linked resource, per [Web Linking (RFC5988)](http://tools.ietf.org/html/rfc5988).  Optional.
+Defines media type of the linked resource, per [Media Type Specifications and Registration Procedures (RFC4288)](http://tools.ietf.org/html/rfc4288).  Optional.
 
 ## Actions
 

--- a/siren.schema.json
+++ b/siren.schema.json
@@ -270,7 +270,7 @@
             }
         },
         "MediaType": {
-            "description": "Defines media type of the linked resource, per Web Linking (RFC5988). For the syntax, see RFC2045 (section 5.1), RFC4288 (section 4.2), RFC6838 (section 4.2)",
+            "description": "Defines media type of the linked resource, per Media Type Specifications and Registration Procedures (RFC4288). For the syntax, see RFC2045 (section 5.1), RFC4288 (section 4.2), RFC6838 (section 4.2)",
             "type": "string",
             "pattern": "^(application|audio|image|message|model|multipart|text|video)\\/([A-Z]|[a-z]|[0-9]|[\\!\\#\\$\\&\\.\\+\\-\\^\\_]){1,127}(; ?(([\\!\\#\\$\\%\\&\\'\\(\\)\\*\\+-\\.\\/]|[0-9]|[A-Z]|[\\^\\_\\`\\]\\|]|[a-z]|[\\|\\~])+)+=((([\\!\\#\\$\\%\\&\\'\\(\\)\\*\\+-\\.\\/]|[0-9]|[A-Z]|[\\^\\_\\`\\]\\|]|[a-z]|[\\|\\~])+)|\"([\\!\\#\\$\\%\\&\\.\\(\\)\\*\\+\\,\\-\\.\\/]|[0-9]|[\\:\\;\\<\\=\\>\\?\\@]|[A-Z]|[\\[\\\\\\]\\^\\_\\`]|[a-z]|[\\{\\|\\}\\~])+\"))*$"
         },


### PR DESCRIPTION
This changes the documentation to link to RFC4288 (Media Type
Specifications and Registration Procedures) when describing type fields.
Before, it referenced RFC5988 (Web Linking), which is not appropriate
in that case.